### PR TITLE
Update install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -62,7 +62,7 @@ function Update-Path {
 Test-GitInstalled
 Test-GitVersion
 
-$force = $args -contains "--force"
+$force = $true
 
 if (Test-Path $installDirectory) {
     if ($force) {


### PR DESCRIPTION
An error occurs because of this line: $force = $args -contains "--force". When I execute the command on Windows, it displays the error: "Error: Existing Shorebird installation detected. Use --force to overwrite." However, upon removing this line and replacing it with $force = $true, I can install Shorebird successfully on Windows by copying and pasting the  command into PowerShell.